### PR TITLE
Enhance MCP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev,test]
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - name: Run tests
+        run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Fast Flights MCP
+
+A Model Context Protocol (MCP) server that exposes the [fast-flights](https://pypi.org/project/fast-flights/) search library.  It provides tools for searching airports and retrieving flight information in a way that works well with Claude or other MCP clients.
+
+## Installation
+
+```bash
+pip install fast-flights-mcp
+```
+
+or clone the repository and install in editable mode:
+
+```bash
+git clone <repo-url>
+cd fast-flights-mcp
+pip install -e .
+```
+
+## Usage
+
+Run the server directly (stdout/stdin transport):
+
+```bash
+fast-flights-mcp
+```
+
+The server exposes two tools:
+
+- `search_airports(query)`: search for airport codes by name
+- `search_flights(...)`: search for one‑way or round‑trip flights
+
+See the docstrings in `fast_flights_mcp.server` for full parameter details.
+
+## Development
+
+Contributions are welcome!  After cloning the repository run:
+
+```bash
+pip install -e .[test]
+```
+
+Install the pre-commit hooks as well:
+
+```bash
+pre-commit install
+```
+
+Then run the test suite:
+
+```bash
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -50,3 +50,23 @@ Then run the test suite:
 ```bash
 pytest
 ```
+
+## MCP client configuration
+
+If your MCP client supports automatic server installation, add the following JSON
+to your `mcp.json` file. The client will clone this repository and launch the
+server for you:
+
+```json
+{
+  "repos": ["https://github.com/example/fast-flights-mcp"],
+  "mcpServers": {
+    "fast-flights-mcp": {
+      "command": "fast-flights-mcp",
+      "env": {}
+    }
+  }
+}
+```
+
+Replace the repo URL with your fork if you wish to make local changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[project]
+name = "fast-flights-mcp"
+version = "0.1.0"
+description = "MCP server wrapping fast-flights API"
+requires-python = ">=3.11"
+dependencies = [
+    "fast-flights>=2.2",
+    "mcp[cli]",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
+dev = [
+    "pre-commit",
+    "black",
+    "ruff",
+] 
+
+[project.scripts]
+fast-flights-mcp = "fast_flights_mcp.server:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+addopts = "-vv"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/fast_flights_mcp"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "MCP server wrapping fast-flights API"
 requires-python = ">=3.11"
 dependencies = [
     "fast-flights>=2.2",
+    "fastmcp",
     "mcp[cli]",
 ]
 

--- a/src/fast_flights_mcp/__init__.py
+++ b/src/fast_flights_mcp/__init__.py
@@ -1,0 +1,21 @@
+"""Fast Flights MCP server."""
+
+from .server import (
+    main,
+    mcp,
+    search_airports,
+    search_flights,
+    seat_classes,
+    plan_trip,
+    compare_airports,
+)
+
+__all__ = [
+    "main",
+    "mcp",
+    "search_airports",
+    "search_flights",
+    "seat_classes",
+    "plan_trip",
+    "compare_airports",
+]

--- a/src/fast_flights_mcp/server.py
+++ b/src/fast_flights_mcp/server.py
@@ -1,0 +1,123 @@
+"""MCP server exposing fast-flights search functions."""
+
+import logging
+from typing import Optional
+
+from fastmcp import FastMCP
+from fast_flights import (
+    search_airport,
+    get_flights,
+    FlightData,
+    Passengers,
+)
+
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP("fast-flights-mcp", dependencies=["fast-flights"])
+
+
+@mcp.tool()
+def search_airports(query: str) -> str:
+    """Return a list of airports matching ``query``."""
+    matches = search_airport(query)
+    if not matches:
+        return "No airports found"
+    lines = [f"{a.name.replace('_', ' ').title()} ({a.value})" for a in matches[:20]]
+    if len(matches) > 20:
+        lines.append(f"...and {len(matches) - 20} more results")
+    return "\n".join(lines)
+
+
+@mcp.resource("flights://seat-classes")
+def seat_classes() -> str:
+    """List the available seat classes."""
+    return "\n".join(["economy", "premium_economy", "business", "first"])
+
+
+@mcp.prompt()
+def plan_trip(destination: str) -> str:
+    """Prompt text to help plan a trip."""
+    return (
+        f"Provide travel tips for visiting {destination}. "
+        "What is the best time to go and approximate costs?"
+    )
+
+
+@mcp.prompt()
+def compare_airports(code1: str, code2: str) -> str:
+    """Prompt to compare flights between two airports."""
+    return (
+        f"Compare flights from {code1} to {code2}. "
+        "Mention airlines, costs and duration."
+    )
+
+
+@mcp.tool()
+def search_flights(
+    from_airport: str,
+    to_airport: str,
+    date: str,
+    *,
+    trip: str = "one-way",
+    return_date: Optional[str] = None,
+    seat: str = "economy",
+    adults: int = 1,
+    children: int = 0,
+    infants_in_seat: int = 0,
+    infants_on_lap: int = 0,
+    max_stops: Optional[int] = None,
+    fetch_mode: str = "common",
+) -> str:
+    """Search for flights using :mod:`fast_flights`."""
+    if trip == "round-trip" and not return_date:
+        raise ValueError("return_date required for round-trip")
+
+    flights = [FlightData(date=date, from_airport=from_airport, to_airport=to_airport)]
+    if trip == "round-trip" and return_date:
+        flights.append(
+            FlightData(
+                date=return_date, from_airport=to_airport, to_airport=from_airport
+            )
+        )
+
+    passengers = Passengers(
+        adults=adults,
+        children=children,
+        infants_in_seat=infants_in_seat,
+        infants_on_lap=infants_on_lap,
+    )
+
+    result = get_flights(
+        flight_data=flights,
+        trip=trip,
+        passengers=passengers,
+        seat=seat,
+        fetch_mode=fetch_mode,
+        max_stops=max_stops,
+    )
+
+    lines = []
+    if hasattr(result, "current_price"):
+        lines.append(f"Price assessment: {result.current_price}")
+
+    for i, fl in enumerate(result.flights[:10], 1):
+        best = " [BEST]" if getattr(fl, "is_best", False) else ""
+        airline = f"{fl.name} " if getattr(fl, "name", "") else ""
+        line = (
+            f"{i}. {airline}{fl.departure} -> {fl.arrival} "
+            f"({fl.duration}) {fl.price}{best}"
+        )
+        lines.append(line)
+    if len(result.flights) > 10:
+        lines.append(f"...and {len(result.flights) - 10} more results")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    """Run the MCP server."""
+    logging.basicConfig(level=logging.INFO)
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+# ensure package can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from fast_flights_mcp import (
+    search_airports,
+    search_flights,
+    seat_classes,
+    plan_trip,
+    compare_airports,
+)
+from fast_flights import Airport, Flight, Result
+import asyncio
+
+
+def test_search_airports(monkeypatch):
+    def fake_search(query: str):
+        return [Airport.SAN_FRANCISCO_INTERNATIONAL_AIRPORT]
+
+    monkeypatch.setattr("fast_flights_mcp.server.search_airport", fake_search)
+    resp = search_airports.fn("san")
+    assert "SFO" in resp
+
+
+def test_search_flights(monkeypatch):
+    flight = Flight(
+        is_best=True,
+        name="Test Airline",
+        departure="SFO 10:00",
+        arrival="LAX 11:30",
+        arrival_time_ahead="",
+        duration="1h30m",
+        stops=0,
+        delay=None,
+        price="$100",
+    )
+    result = Result(current_price="low", flights=[flight])
+
+    def fake_get_flights(**kwargs):
+        return result
+
+    monkeypatch.setattr("fast_flights_mcp.server.get_flights", fake_get_flights)
+
+    resp = search_flights.fn("SFO", "LAX", "2025-01-01")
+    assert "Test Airline" in resp
+    assert "$100" in resp
+
+
+def test_resources_and_prompts():
+    assert "economy" in asyncio.run(seat_classes.read())
+    msg1 = asyncio.run(compare_airports.render({"code1": "SFO", "code2": "LAX"}))
+    assert "SFO" in msg1[0].content.text
+    msg2 = asyncio.run(plan_trip.render({"destination": "Tokyo"}))
+    assert "Tokyo" in msg2[0].content.text


### PR DESCRIPTION
## Summary
- import `FastMCP` from `fastmcp`
- expose seat class resource and helpful prompts
- document pre‑commit usage
- add pre‑commit configuration and dev extras
- expand tests for new resource and prompts

## Testing
- `pre-commit run --files tests/test_server.py src/fast_flights_mcp/server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f984a040c832aaa5643f795704593