### PR TITLE
Add examples, contrib docs, and coverage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug Report
+about: Report a reproducible bug
+labels: bug
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '...'
+3. Observe error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Suggest an idea
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear description of the problem.
+
+**Describe the solution you'd like**
+A clear description of the feature you want.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+## Summary
+Explain the changes and why they are needed.
+
+## Testing
+- [ ] `pre-commit run --all-files`
+- [ ] `pytest`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --show-diff-on-failure --color=always --all-files
       - name: Run tests
-        run: pytest -q
+        run: pytest --cov=fast_flights_mcp --cov-report=xml -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+Thanks for your interest in contributing! To set up a development environment run:
+
+```bash
+pip install -e .[dev,test]
+pre-commit install
+```
+
+Run the test suite with:
+
+```bash
+pytest --cov=fast_flights_mcp
+```
+
+Please open an issue before submitting large changes.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fast Flights MCP
 
+[![CI](https://github.com/example/fast-flights-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/example/fast-flights-mcp/actions/workflows/ci.yml)
+
 A Model Context Protocol (MCP) server that exposes the [fast-flights](https://pypi.org/project/fast-flights/) search library.  It provides tools for searching airports and retrieving flight information in a way that works well with Claude or other MCP clients.
 
 ## Installation
@@ -31,9 +33,17 @@ The server exposes two tools:
 
 See the docstrings in `fast_flights_mcp.server` for full parameter details.
 
+For more examples see [docs/examples.md](docs/examples.md). A quick Python usage
+snippet:
+
+```python
+from fast_flights_mcp import search_airports
+print(search_airports.fn("san"))
+```
+
 ## Development
 
-Contributions are welcome!  After cloning the repository run:
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for details. After cloning the repository run:
 
 ```bash
 pip install -e .[test]
@@ -45,10 +55,10 @@ Install the pre-commit hooks as well:
 pre-commit install
 ```
 
-Then run the test suite:
+Then run the test suite with coverage:
 
 ```bash
-pytest
+pytest --cov=fast_flights_mcp --cov-report=term-missing
 ```
 
 ## MCP client configuration

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,17 @@
+# Usage Examples
+
+Here are a few short examples using the tools provided by the server.
+
+## Search for airports
+```python
+from fast_flights_mcp import search_airports
+print(search_airports.fn("san"))
+```
+
+## Search for flights
+```python
+from fast_flights_mcp import search_flights
+print(search_flights.fn("SFO", "LAX", "2025-01-01"))
+```
+
+See the `fast_flights_mcp.server` module for full parameter details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
+    "pytest-cov",
 ]
 dev = [
     "pre-commit",

--- a/tests/test_server_extra.py
+++ b/tests/test_server_extra.py
@@ -13,8 +13,6 @@ def test_search_airports_no_results(monkeypatch):
 
 
 def test_search_flights_roundtrip_missing_return(monkeypatch):
-    monkeypatch.setattr(
-        "fast_flights_mcp.server.get_flights", lambda **kw: None
-    )
+    monkeypatch.setattr("fast_flights_mcp.server.get_flights", lambda **kw: None)
     with pytest.raises(ValueError):
         search_flights.fn("SFO", "LAX", "2025-01-01", trip="round-trip")

--- a/tests/test_server_extra.py
+++ b/tests/test_server_extra.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from fast_flights_mcp import search_airports, search_flights
+
+
+def test_search_airports_no_results(monkeypatch):
+    monkeypatch.setattr("fast_flights_mcp.server.search_airport", lambda q: [])
+    assert search_airports.fn("nowhere") == "No airports found"
+
+
+def test_search_flights_roundtrip_missing_return(monkeypatch):
+    monkeypatch.setattr(
+        "fast_flights_mcp.server.get_flights", lambda **kw: None
+    )
+    with pytest.raises(ValueError):
+        search_flights.fn("SFO", "LAX", "2025-01-01", trip="round-trip")


### PR DESCRIPTION
## Summary
- add CI badge and example snippet to README
- document usage examples under docs/
- provide CONTRIBUTING guidelines
- add issue and PR templates
- enable coverage in CI and add tests for errors

## Testing
- `pre-commit run --show-diff-on-failure --color=always --all-files`
- `pytest --cov=fast_flights_mcp --cov-report=term-missing:skip-covered -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa6fc7c7c832a872fa7e9820fddf4