### PR TITLE
Add contribution docs and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Report a bug with fast-flights-mcp
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+# Summary
+
+Provide a short description of the changes introduced in this PR.
+
+# Checklist
+
+- [ ] Tests added or updated
+- [ ] Pre-commit checks pass (`pre-commit run --all-files`)
+- [ ] Documentation updated (if needed)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project and everyone participating in it is expected to adhere to the
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+We pledge to foster an open and welcoming environment. Harassment of project
+participants in any form will not be tolerated. Instances of abusive,
+harassing, or otherwise unacceptable behavior may be reported by creating an
+issue or contacting the maintainers privately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Thank you for wanting to contribute! To get started:
+
+1. Fork the repository and create a new branch for your change.
+2. Install the development dependencies:
+
+   ```bash
+   pip install -e .[dev,test]
+   pre-commit install
+   ```
+
+3. Run the pre-commit checks and test suite:
+
+   ```bash
+   pre-commit run --all-files
+   pytest
+   ```
+
+4. Open a pull request explaining your changes.
+
+Please keep commits focused and include tests when possible. For questions or
+large changes, open an issue first to discuss.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ See the docstrings in `fast_flights_mcp.server` for full parameter details.
 
 ## Development
 
-Contributions are welcome!  After cloning the repository run:
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed
+instructions. After cloning the repository run:
 
 ```bash
 pip install -e .[test]
@@ -70,3 +71,7 @@ server for you:
 ```
 
 Replace the repo URL with your fork if you wish to make local changes.
+
+## Code of Conduct
+
+Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide and code of conduct
- add issue and PR templates
- reference new docs from README

## Testing
- `pre-commit run --files README.md CODE_OF_CONDUCT.md CONTRIBUTING.md .github/ISSUE_TEMPLATE/bug_report.md .github/ISSUE_TEMPLATE/feature_request.md .github/PULL_REQUEST_TEMPLATE.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fa739531c832aba6804f20a726b4e