### PR TITLE
Fix Node entrypoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 const { spawn } = require('child_process');
 
-const child = spawn('fast-flights-mcp', { stdio: 'inherit' });
+// Run the Python entrypoint directly to avoid missing CLI errors
+const child = spawn('python3', ['-m', 'fast_flights_mcp.server', ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    PYTHONPATH: `${__dirname}/src`,
+  },
+});
 child.on('close', code => process.exit(code));

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "fast-flights-mcp": "./index.js"
   },
   "scripts": {
-    "postinstall": "pip install git+https://github.com/jonzarecki/fast-flights-mcp"
+    "postinstall": "pip install --user ."
   }
 }


### PR DESCRIPTION
## Summary
- run Python module directly from Node entrypoint and forward CLI args
- install package locally in npm `postinstall`

## Testing
- `pip install -e .[test]`
- `pytest -q`
- `npm install`
- `node index.js < /dev/null > /tmp/server.log`

------
https://chatgpt.com/codex/tasks/task_e_686814b72c78832aa32442989030a71c